### PR TITLE
Ensure page is loaded on History.replaceState changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@sinonjs/commons": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.0.2.tgz",
-      "integrity": "sha512-WR3dlgqJP4QNrLC4iXN/5/2WaLQQ0VijOOkmflqFGVJ6wLEpbSjo7c0ZeGIdtY8Crk7xBBp87sM6+Mkerz7alw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
+      "integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
@@ -34,13 +34,10 @@
       }
     },
     "@sinonjs/samsam": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.1.tgz",
-      "integrity": "sha512-7oX6PXMulvdN37h88dvlvRyu61GYZau40fL4wEZvPEHvrjpJc3lDv6xDM5n4Z0StufUVB5nDvVZUM+jZHdMOOQ==",
-      "dev": true,
-      "requires": {
-        "array-from": "^2.1.1"
-      }
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.2.tgz",
+      "integrity": "sha512-ZwTHAlC9akprWDinwEPD4kOuwaYZlyMwVJIANsKNC3QVp0AHB04m7RnB4eqeWfgmxw8MGTzS9uMaw93Z3QcZbw==",
+      "dev": true
     },
     "@types/estree": {
       "version": "0.0.39",
@@ -820,7 +817,7 @@
     },
     "engine.io-client": {
       "version": "3.2.1",
-      "resolved": "http://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
       "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
       "dev": true,
       "requires": {
@@ -1225,14 +1222,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1252,8 +1247,7 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -1401,7 +1395,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2589,9 +2582,9 @@
       }
     },
     "lolex": {
-      "version": "2.7.5",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
-      "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-3.0.0.tgz",
+      "integrity": "sha512-hcnW80h3j2lbUfFdMArd5UPA/vxZJ+G8vobd+wg3nVEQA0EigStbYcrG030FJxL6xiDDPEkoMatV9xIh5OecQQ==",
       "dev": true
     },
     "lru-cache": {
@@ -2617,7 +2610,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -2840,9 +2833,9 @@
       "dev": true
     },
     "nise": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.5.tgz",
-      "integrity": "sha512-OHRVvdxKgwZELf2DTgsJEIA4MOq8XWvpSUzoOXyxJ2mY0mMENWC66+70AShLR2z05B1dzrzWlUQJmJERlOUpZw==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.6.tgz",
+      "integrity": "sha512-1GedetLKzmqmgwabuMSqPsT7oumdR77SBpDfNNJhADRIeA3LN/2RVqR4fFqwvzhAqcTef6PPCzQwITE/YQ8S8A==",
       "dev": true,
       "requires": {
         "@sinonjs/formatio": "3.0.0",
@@ -2850,6 +2843,14 @@
         "lolex": "^2.3.2",
         "path-to-regexp": "^1.7.0",
         "text-encoding": "^0.6.4"
+      },
+      "dependencies": {
+        "lolex": {
+          "version": "2.7.5",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+          "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+          "dev": true
+        }
       }
     },
     "normalize-path": {
@@ -3316,18 +3317,18 @@
       "dev": true
     },
     "sinon": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.3.4.tgz",
-      "integrity": "sha512-NIaR56Z1mefuRBXYrf4otqBxkWiKveX+fvqs3HzFq2b07HcgpkMgIwmQM/owNjNFAHkx0kJXW+Q0mDthiuslXw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.1.1.tgz",
+      "integrity": "sha512-iYagtjLVt1vN3zZY7D8oH7dkjNJEjLjyuzy8daX5+3bbQl8gaohrheB9VfH1O3L6LKuue5WTJvFluHiuZ9y3nQ==",
       "dev": true,
       "requires": {
-        "@sinonjs/commons": "^1.0.2",
+        "@sinonjs/commons": "^1.2.0",
         "@sinonjs/formatio": "^3.0.0",
-        "@sinonjs/samsam": "^2.1.1",
+        "@sinonjs/samsam": "^2.1.2",
         "diff": "^3.5.0",
         "lodash.get": "^4.4.2",
-        "lolex": "^2.7.4",
-        "nise": "^1.4.5",
+        "lolex": "^3.0.0",
+        "nise": "^1.4.6",
         "supports-color": "^5.5.0",
         "type-detect": "^4.0.8"
       },
@@ -3517,7 +3518,7 @@
     },
     "socket.io-parser": {
       "version": "3.2.0",
-      "resolved": "http://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
       "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
       "dev": true,
       "requires": {
@@ -3656,7 +3657,7 @@
     },
     "text-encoding": {
       "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "rollup": "^0.65.2",
     "rollup-plugin-node-resolve": "^3.4.0",
     "rollup-plugin-typescript": "^0.8.1",
-    "sinon": "^6.3.4",
+    "sinon": "^7.1.1",
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.15.0",
     "typescript": "^3.0.3",

--- a/tests/router-component-tests.js
+++ b/tests/router-component-tests.js
@@ -6,14 +6,6 @@ const { assert } = chai;
 
 describe('Router Component', function () {
 
-    beforeEach(() => {
-        sinon.stub(window.history, 'pushState');
-    });
-
-    afterEach(() => {
-        window.history.pushState.restore();
-    });
-
     it('should remove all children from the dom when instantiated if none match the current route', function () {
         const tpl = document.createElement('template');
         tpl.innerHTML = `
@@ -22,11 +14,7 @@ describe('Router Component', function () {
             </router-component>
         `;
         const component = tpl.content.querySelector('router-component');
-        Object.defineProperty(component, 'location', {
-            value: {
-                pathname: '/'
-            }
-        });
+        window.history.pushState({}, document.title, '/');
         document.body.appendChild(tpl.content);
         assert.ok(!document.body.querySelector('first-page'));
         component.remove();
@@ -54,11 +42,7 @@ describe('Router Component', function () {
             </router-component>
         `;
         const component = tpl.content.querySelector('router-component');
-        Object.defineProperty(component, 'location', {
-            value: {
-                pathname: '/blah.html'
-            }
-        });
+        window.history.pushState({}, document.title, '/blah.html');
         document.body.appendChild(tpl.content);
         const firstPage = document.body.querySelector('first-page');
         assert.deepEqual(firstPage.parentElement, component);
@@ -74,11 +58,7 @@ describe('Router Component', function () {
         `;
         const component = tpl.content.querySelector('router-component');
         const dir = 'this/is/a/deep/path/with/a/';
-        Object.defineProperty(component, 'location', {
-            value: {
-                pathname: `${dir}file.html`
-            }
-        });
+        window.history.pushState({}, document.title, `${dir}file.html`);
         document.body.appendChild(tpl.content);
         const firstPage = document.body.querySelector('first-page');
         assert.deepEqual(firstPage.parentElement, component);
@@ -93,11 +73,7 @@ describe('Router Component', function () {
             </router-component>
         `;
         const component = tpl.content.querySelector('router-component');
-        Object.defineProperty(component, 'location', {
-            value: {
-                pathname: '/test/path/page1'
-            }
-        });
+        window.history.pushState({}, document.title, '/test/path/page1');
         document.body.appendChild(tpl.content);
         const firstPage = document.body.querySelector('first-page');
         assert.deepEqual(firstPage.parentElement, component);
@@ -112,12 +88,7 @@ describe('Router Component', function () {
             </router-component>
         `;
         const component = tpl.content.querySelector('router-component');
-        Object.defineProperty(component, 'location', {
-            value: {
-                pathname: '/page1',
-                search: '?foo=bar'
-            }
-        });
+        window.history.pushState({}, document.title, '/page1?foo=bar');
         document.body.appendChild(tpl.content);
         const firstPage = document.body.querySelector('first-page');
         assert.deepEqual(firstPage.parentElement, component);
@@ -132,12 +103,7 @@ describe('Router Component', function () {
             </router-component>
         `;
         const component = tpl.content.querySelector('router-component');
-        Object.defineProperty(component, 'location', {
-            value: {
-                pathname: '/page1',
-                search: '?foo=baz'
-            }
-        });
+        window.history.pushState({}, document.title, '/page1?foo=baz');
         document.body.appendChild(tpl.content);
         assert.ok(document.body.querySelector('first-page'));
         component.remove();
@@ -152,11 +118,7 @@ describe('Router Component', function () {
             </router-component>
         `;
         const component = tpl.content.querySelector('router-component');
-        Object.defineProperty(component, 'location', {
-            value: {
-                pathname: '/page1'
-            }
-        });
+        window.history.pushState({}, document.title, '/page1');
         document.body.appendChild(tpl.content);
         const firstPage = document.body.querySelector('first-page');
         assert.deepEqual(firstPage.parentElement, component);
@@ -173,14 +135,9 @@ describe('Router Component', function () {
             </router-component>
         `;
         const component = tpl.content.querySelector('router-component');
-        Object.defineProperty(component, 'location', {
-            value: {
-                pathname: '/page1'
-            },
-            configurable: true
-        });
+        window.history.pushState({}, document.title, '/page1');
         document.body.appendChild(tpl.content);
-        component.location.pathname = '/page2';
+        window.history.pushState({}, document.title, '/page2');
         const popstate = new PopStateEvent('popstate', { state: {} });
         window.dispatchEvent(popstate);
         assert.ok(!document.body.querySelector('first-page'));
@@ -197,11 +154,7 @@ describe('Router Component', function () {
             </router-component>
         `;
         const component = tpl.content.querySelector('router-component');
-        Object.defineProperty(component, 'location', {
-            value: {
-                pathname: '/page1'
-            },
-        });
+        window.history.pushState({}, document.title, '/page1');
         document.body.appendChild(tpl.content);
         const newPath = 'nope';
         assert.throws(() => component.show(newPath), Error, `Navigated to path "${newPath}" but there is no matching ` +
@@ -218,11 +171,7 @@ describe('Router Component', function () {
             </router-component>
         `;
         const component = tpl.content.querySelector('router-component');
-        Object.defineProperty(component, 'location', {
-            value: {
-                pathname: '/page1'
-            }
-        });
+        window.history.pushState({}, document.title, '/page1');
         document.body.appendChild(tpl.content);
         assert.ok(!document.body.querySelector('first-page'));
         assert.ok(document.body.querySelector('second-page'));
@@ -239,9 +188,7 @@ describe('Router Component', function () {
         `;
         const component = tpl.content.querySelector('router-component');
         const pathname = '/page1';
-        Object.defineProperty(component, 'location', {
-            value: {pathname},
-        });
+        window.history.pushState({}, document.title, pathname);
         document.body.appendChild(tpl.content);
         assert.doesNotThrow(() => component.show(pathname));
         assert.ok(document.body.querySelector('first-page'));
@@ -258,9 +205,7 @@ describe('Router Component', function () {
             </router-component>
         `;
         const component = tpl.content.querySelector('router-component');
-        Object.defineProperty(component, 'location', {
-            value: {pathname: '/page'},
-        });
+        window.history.pushState({}, document.title, '/page');
         document.body.appendChild(tpl.content);
         // showing first page
         assert.doesNotThrow(() => component.show('/page/2'));
@@ -280,19 +225,11 @@ describe('Router Component', function () {
             </router-component>
         `;
         const component = tpl.content.querySelector('router-component');
-        Object.defineProperty(component, 'location', {
-            value: {
-                pathname: '/page1',
-                origin: window.location.origin
-            },
-            configurable: true
-        });
         document.body.appendChild(tpl.content);
+        window.history.pushState({}, document.title, '/page1');
         const firstPageLink = document.querySelector('first-page a');
         const timer = setTimeout(() => {
-            component.location.pathname = '/page2';
             firstPageLink.click();
-            assert.deepEqual(window.history.pushState.args[0], [{}, document.title, '/page2']);
             assert.ok(!document.body.querySelector('first-page'));
             assert.ok(document.body.querySelector('second-page'));
             component.remove();
@@ -312,18 +249,11 @@ describe('Router Component', function () {
             </router-component>
         `;
         const component = tpl.content.querySelector('router-component');
-        Object.defineProperty(component, 'location', {
-            value: {
-                pathname: '/page1',
-                origin: window.location.origin
-            },
-        });
+        window.history.pushState({}, document.title, '/page1');
         document.body.appendChild(tpl.content);
         const firstPageLink = document.querySelector('first-page a');
         const timer = setTimeout(() => {
-            component.location.pathname = '/';
             firstPageLink.click();
-            assert.deepEqual(window.history.pushState.args[0], [{}, document.title, '/']);
             assert.ok(!document.body.querySelector('first-page'));
             assert.ok(document.body.querySelector('home-page'));
             component.remove();
@@ -343,18 +273,11 @@ describe('Router Component', function () {
             </router-component>
         `;
         const component = tpl.content.querySelector('router-component');
-        Object.defineProperty(component, 'location', {
-            value: {
-                pathname: '/page1',
-                origin: window.location.origin
-            },
-        });
         document.body.appendChild(tpl.content);
+        window.history.pushState({}, document.title, '/page1');
         const firstPageLink = document.querySelector('first-page a');
         const timer = setTimeout(() => {
-            component.location.pathname = '/';
             firstPageLink.click();
-            assert.deepEqual(window.history.pushState.args[0], [{}, document.title, '/']);
             assert.ok(!document.body.querySelector('first-page'));
             assert.ok(document.body.querySelector('fallback-page'));
             component.remove();
@@ -374,25 +297,59 @@ describe('Router Component', function () {
             </router-component>
         `;
         const component = tpl.content.querySelector('router-component');
-        Object.defineProperty(component, 'location', {
-            value: {
-                pathname: '/page1',
-                origin: window.location.origin
-            },
-        });
+        window.history.pushState({}, document.title, '/page1');
         document.body.appendChild(tpl.content);
         const firstPageLink = document.querySelector('first-page a');
         const timer = setTimeout(() => {
             const evt = new Event('click');
             evt.preventDefault();
             firstPageLink.dispatchEvent(evt);
-            assert.equal(window.history.pushState.callCount, 0);
             assert.ok(document.body.querySelector('first-page'));
             assert.ok(!document.body.querySelector('second-page'));
             component.remove();
             clearTimeout(timer);
             done();
         }, 201);
+    });
+
+    it('should switch to the path that matches the current location after calling pushState', function () {
+        const tpl = document.createElement('template');
+        tpl.innerHTML = `
+            <router-component>
+                <first-page path="/page1"></first-page>
+                <second-page path="/page2"></second-page>
+            </router-component>
+        `;
+        const component = tpl.content.querySelector('router-component');
+        window.history.pushState({}, document.title, '/page1');
+        document.body.appendChild(tpl.content);
+        const state = {my: 'state'};
+        const pageTitle = 'the title';
+        const url = '/page2';
+        window.history.pushState(state, pageTitle, url);
+        assert.ok(!document.body.querySelector('first-page'));
+        assert.ok(document.body.querySelector('second-page'));
+        component.remove();
+    });
+
+    it('should switch to the path that matches the current location after calling replaceState', function () {
+        const tpl = document.createElement('template');
+        tpl.innerHTML = `
+            <router-component>
+                <first-page path="/page1"></first-page>
+                <second-page path="/page2"></second-page>
+            </router-component>
+        `;
+        const component = tpl.content.querySelector('router-component');
+        window.history.pushState({}, document.title, '/page1');
+        document.body.appendChild(tpl.content);
+        const state = {my: 'state'};
+        const pageTitle = 'the title';
+        const url = '/page2';
+        window.history.replaceState(state, pageTitle, url);
+        assert.ok(!document.body.querySelector('first-page'));
+        assert.ok(document.body.querySelector('second-page'));
+        component.remove();
     });
 
     describe('extractPathParams', function () {


### PR DESCRIPTION
Fixes an issue where router pages weren't being loaded when replaceState
was being used. Also simplifies the code a bit and ensures listeners are
removed when the router component is disconnected from the DOM.

Upgrades tests to not mock out pushState/replaceState which is
unnecessary.

Oh and upgrades sinon package which was pretty outdated.