### PR TITLE
Support non-renderable route changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,16 @@ There are two ways that a route can be changed.
 window.history.pushState({}, null, '/new-url');
 
 ```
+Each method will trigger the `route-changed` event that is dispatched by the router component itself, which is illustrated in the next section below. 
 
-Each method will trigger the `route-changed` event that is dispatched by the router component itself, which is illustrated in the next section below.
+In the rare case you would like to push a new state or change the current location without triggering a new route, you 
+can pass `triggerRouteChange` flag like this:
+
+```javascript
+window.history.pushState({triggerRouteChange: false}, null, '/new-url');
+``` 
+
+Router will clean up the `triggerRoute` property in `history.state`, so you don't need to worry about clearing it out.
 
 ### Detecting Route Changes
 

--- a/tests/router-component-tests.js
+++ b/tests/router-component-tests.js
@@ -434,6 +434,27 @@ describe('Router Component', function() {
         parentRouter.remove();
     });
 
+    it('should only call on router show once per click', function() {
+        const tpl = document.createElement('template');
+        tpl.innerHTML = `
+            <router-component>
+                <first-page path="/page1">
+                    <a href="/page2">To page 2</a>
+                </first-page>
+                <second-page path="/page2"></second-page>
+            </router-component>
+        `;
+        const component = tpl.content.querySelector('router-component');
+        window.history.pushState({}, document.title, '/page1');
+        document.body.appendChild(tpl.content);
+        const firstPage = document.querySelector('first-page');
+        sinon.spy(component, 'show');
+        const firstPageLink = firstPage.querySelector('a');
+        firstPageLink.click();
+        assert.ok(component.show.callCount, 1);
+        component.remove();
+    });
+
     describe('when triggerRouteChange is set to false when pushing new state', function() {
         let component;
 

--- a/tests/router-component-tests.js
+++ b/tests/router-component-tests.js
@@ -481,6 +481,11 @@ describe('Router Component', function() {
             assert.ok(document.body.querySelector('first-page'));
             assert.ok(!document.body.querySelector('second-page'));
         });
+
+        it('should not change the route if null is passed as the state', function() {
+            window.history.pushState(null, null, '/page3');
+            assert.ok(document.body.querySelector('first-page'));
+        });
     });
 
     describe('extractPathParams', function() {

--- a/tests/router-component-tests.js
+++ b/tests/router-component-tests.js
@@ -436,6 +436,7 @@ describe('Router Component', function() {
 
     describe('when triggerRouteChange is set to false when pushing new state', function() {
         let component;
+
         beforeEach(function() {
             const tpl = document.createElement('template');
             tpl.innerHTML = `
@@ -484,6 +485,12 @@ describe('Router Component', function() {
 
         it('should not change the route if null is passed as the state', function() {
             window.history.pushState(null, null, '/page3');
+            assert.ok(document.body.querySelector('first-page'));
+        });
+        it('should go back to previous route and continue to show previous page when requested', function() {
+            window.history.pushState({ triggerRouteChange: false }, null, '/page3');
+            window.history.pushState({}, null, '/page1');
+            assert.equal(location.pathname, '/page1');
             assert.ok(document.body.querySelector('first-page'));
         });
     });

--- a/tests/router-component-tests.js
+++ b/tests/router-component-tests.js
@@ -447,11 +447,12 @@ describe('Router Component', function() {
         const component = tpl.content.querySelector('router-component');
         window.history.pushState({}, document.title, '/page1');
         document.body.appendChild(tpl.content);
-        const firstPage = document.querySelector('first-page');
         sinon.spy(component, 'show');
+        const firstPage = document.querySelector('first-page');
+        assert.equal(component.show.callCount, 0);
         const firstPageLink = firstPage.querySelector('a');
         firstPageLink.click();
-        assert.ok(component.show.callCount, 1);
+        assert.equal(component.show.callCount, 1);
         component.remove();
     });
 

--- a/tslint.json
+++ b/tslint.json
@@ -8,7 +8,8 @@
   "rules": {
     "member-access": false,
     "curly": false,
-    "typedef": [true, "parameter", "member-variable-declaration"]
+    "typedef": [true, "parameter", "member-variable-declaration"],
+    "no-console": [true, "log", "error"]
 
   },
   "rulesDirectory": []


### PR DESCRIPTION
* Updates to support setting `triggerRouteChange` to `false` on state
change to allow changing routes without actually triggering the rendering
engine
* No longer throwing errors on non-matching routes, warnings for
consumer are better (plus its better for tests)
* Fixes a bug where clicking on a link would render a route twice
* Added tests